### PR TITLE
Mysql startup error fix

### DIFF
--- a/files/start.sh
+++ b/files/start.sh
@@ -44,7 +44,7 @@ if ( ! grep -q 'database.*=>.*drupal' ${DOCROOT}/sites/default/settings.php ); t
   echo ${DRUPAL_PASSWORD} > /var/lib/mysql/mysql/drupal-db-pw.txt
   # Wait for mysql. Password is initially empty.
   echo "Checking if mysql is running..."
-  while ! sleep 1 && mysqladmin -u root status 2>/dev/null; do sleep 0.1; done
+  while ! mysqladmin -u root status 2>/dev/null; do sleep 0.1; done
   # Create and change MySQL creds
   mysqladmin -u root password ${ROOT_PASSWORD} 2>/dev/null
   mysql -uroot -p${ROOT_PASSWORD} -e \

--- a/files/start.sh
+++ b/files/start.sh
@@ -42,10 +42,9 @@ if ( ! grep -q 'database.*=>.*drupal' ${DOCROOT}/sites/default/settings.php ); t
   DRUPAL_PASSWORD=`pwgen -c -n -1 12`
   echo ${ROOT_PASSWORD} > /var/lib/mysql/mysql/mysql-root-pw.txt
   echo ${DRUPAL_PASSWORD} > /var/lib/mysql/mysql/drupal-db-pw.txt
-  # Wait for mysql
-  while ! nc -z localhost 3306; do sleep 0.1; done
-  # Some macs are slow to start mysql
-  sleep 3
+  # Wait for mysql. Password is initially empty.
+  echo "Checking if mysql is running..."
+  while ! mysqladmin -u root status; do sleep 0.1; done
   # Create and change MySQL creds
   mysqladmin -u root password ${ROOT_PASSWORD} 2>/dev/null
   mysql -uroot -p${ROOT_PASSWORD} -e \

--- a/files/start.sh
+++ b/files/start.sh
@@ -44,7 +44,7 @@ if ( ! grep -q 'database.*=>.*drupal' ${DOCROOT}/sites/default/settings.php ); t
   echo ${DRUPAL_PASSWORD} > /var/lib/mysql/mysql/drupal-db-pw.txt
   # Wait for mysql. Password is initially empty.
   echo "Checking if mysql is running..."
-  while ! mysqladmin -u root status; do sleep 0.1; done
+  while ! mysqladmin -u root status 2>/dev/null; do sleep 0.1; done
   # Create and change MySQL creds
   mysqladmin -u root password ${ROOT_PASSWORD} 2>/dev/null
   mysql -uroot -p${ROOT_PASSWORD} -e \

--- a/files/start.sh
+++ b/files/start.sh
@@ -44,7 +44,7 @@ if ( ! grep -q 'database.*=>.*drupal' ${DOCROOT}/sites/default/settings.php ); t
   echo ${DRUPAL_PASSWORD} > /var/lib/mysql/mysql/drupal-db-pw.txt
   # Wait for mysql. Password is initially empty.
   echo "Checking if mysql is running..."
-  while ! mysqladmin -u root status 2>/dev/null; do sleep 0.1; done
+  while ! sleep 1 && mysqladmin -u root status 2>/dev/null; do sleep 0.1; done
   # Create and change MySQL creds
   mysqladmin -u root password ${ROOT_PASSWORD} 2>/dev/null
   mysql -uroot -p${ROOT_PASSWORD} -e \


### PR DESCRIPTION
This fixes the Error "[ERROR] Fatal error: Can't open and lock privilege tables: Table storage engine for 'user' doesn't have this option".

The error occurs because the mysql password is not changed. The password is not changed because when the mysqladmin password command is run, the mysql instance is not yet running.

The fix is to improve the check whether mysql is running.

To test the fix, you can run: `docker run -i -t -p 80:80 -p 8022:22 -p 3306:3306 bitjumpio/drupal8`