### PR TITLE
Fix incorrect syntax in win batch file

### DIFF
--- a/drupal8_test.sh
+++ b/drupal8_test.sh
@@ -5,8 +5,8 @@ export WEBPORT="$(((RANDOM % 10000)+ 50000))"
 export DBPORT="$(((RANDOM % 10000)+ 51000))"
 
 echo "**** Starting Drupal Trial Test Run with ephemeral data ****"
-echo "     Using MYSQL PORT: ${DBPORT}"
-echo "     Using HTTP  URL : http://localhost:${WEBPORT}"
+echo "     Using MYSQL PORT: %DBPORT%"
+echo "     Using HTTP  URL : http://localhost:%WEBPORT%"
 
 # Create a network
 docker network create --subnet=10.8.8.0/16 drupalnet 2>/dev/null || true

--- a/drupal8_test.sh
+++ b/drupal8_test.sh
@@ -14,6 +14,6 @@ docker network create --subnet=10.8.8.0/16 drupalnet 2>/dev/null || true
 # Run the container
 docker run -it \
   --net drupalnet \
-  -p ${WEBPORT}:80 \
-  -p ${DBPORT}:3306 \
+  -p %WEBPORT%:80 \
+  -p %DBPORT%:3306 \
   ricardoamaro/drupal8


### PR DESCRIPTION
Corrects incorrect variable interpolation syntax on the final line, as well as in the echo statements.  Echo statements appear to be fixed already in the master branch, despite my cloning master only a few minutes earlier.